### PR TITLE
Add option to use different moonscript compiler.

### DIFF
--- a/lua/moonmaker.lua
+++ b/lua/moonmaker.lua
@@ -237,9 +237,18 @@ local MoonMaker
 do
   local _class_0
   local _base_0 = {
+    getCompiler = function()
+      if Vim.callFunction('exists', {
+        'g:MoonCompiler'
+      }) == 1 then
+        return vim.api.nvim_get_var('MoonCompiler')
+      else
+        return "moonc"
+      end
+    end,
     executeMoon = function(moonText)
       local luaText = Vim.callFunction("system", {
-        "moonc --",
+        MoonMaker.getCompiler() .. " --",
         moonText
       })
       return loadstring(luaText)()
@@ -248,7 +257,7 @@ do
       if not File.exists(luaPath) or timeStampIsGreater(moonPath, luaPath) then
         Path.makeMissingDirectoriesInPath(luaPath)
         local output = Vim.callFunction("system", {
-          "moonc -o \"" .. tostring(luaPath) .. "\" \"" .. tostring(moonPath) .. "\""
+          MoonMaker.getCompiler() .. " -o \"" .. tostring(luaPath) .. "\" \"" .. tostring(moonPath) .. "\""
         })
         if Vim.eval('v:shell_error') ~= 0 then
           Vim.echoError("Errors occurred while compiling file '" .. tostring(moonPath) .. "'")

--- a/moon/moonmaker.moon
+++ b/moon/moonmaker.moon
@@ -104,22 +104,20 @@ timeStampIsGreater = (file1Path, file2Path) ->
 
 class MoonMaker
   getCompiler: () ->
-      if Vim.callFunction('exists', {'MoonCompiler'}) == 1
+      if Vim.callFunction('exists', {'g:MoonCompiler'}) == 1
           return vim.api.nvim_get_var('MoonCompiler')
       else
           return "moonc"
 
   executeMoon: (moonText) ->
-    local moon_cmd = getCompiler() .. " --"
-    luaText = Vim.callFunction("system", { moon_cmd, moonText })
+    luaText = Vim.callFunction("system", { MoonMaker.getCompiler() .. " --", moonText })
     loadstring(luaText)!
 
   -- Returns true if it was compiled
   compileMoonIfOutOfDate: (moonPath, luaPath) ->
-    local moon_cmd = getCompiler() .. " -o "
     if not File.exists(luaPath) or timeStampIsGreater(moonPath, luaPath)
       Path.makeMissingDirectoriesInPath(luaPath)
-      output = Vim.callFunction("system", { moon_cmd .. "#{luaPath} " .. "#{moonPath}" })
+      output = Vim.callFunction("system", { MoonMaker.getCompiler() .. " -o \"#{luaPath}\" \"#{moonPath}\"" })
 
       if Vim.eval('v:shell_error') != 0
         Vim.echoError("Errors occurred while compiling file '#{moonPath}'")

--- a/moon/moonmaker.moon
+++ b/moon/moonmaker.moon
@@ -1,3 +1,8 @@
+moon_compiler = vim.g.moon_compiler or "moonc"
+
+-- TODO either make use of this or change to some boolean option
+-- to allow to use yuescripts's minify option.
+moon_compile_extra_opts = vim.g.moon_compile_extra_opts or ""
 
 class Vim
   eval: (vimL) ->
@@ -104,16 +109,18 @@ timeStampIsGreater = (file1Path, file2Path) ->
     return time1 > time2
 
 class MoonMaker
+  compiler: moon_compiler
   executeMoon: (moonText) ->
-    luaText = Vim.callFunction("system", { "moonc --", moonText })
+    local moon_cmd = compiler .. " --"
+    luaText = Vim.callFunction("system", { moon_cmd, moonText })
     loadstring(luaText)!
 
   -- Returns true if it was compiled
   compileMoonIfOutOfDate: (moonPath, luaPath) ->
-
+    local moon_cmd = compiler .. " -o "
     if not File.exists(luaPath) or timeStampIsGreater(moonPath, luaPath)
       Path.makeMissingDirectoriesInPath(luaPath)
-      output = Vim.callFunction("system", { "moonc -o \"#{luaPath}\" \"#{moonPath}\"" })
+      output = Vim.callFunction("system", { moon_cmd .. "#{luaPath} " .. "#{moonPath}" })
 
       if Vim.eval('v:shell_error') != 0
         Vim.echoError("Errors occurred while compiling file '#{moonPath}'")

--- a/moon/moonmaker.moon
+++ b/moon/moonmaker.moon
@@ -1,9 +1,3 @@
-moon_compiler = vim.g.moon_compiler or "moonc"
-
--- TODO either make use of this or change to some boolean option
--- to allow to use yuescripts's minify option.
-moon_compile_extra_opts = vim.g.moon_compile_extra_opts or ""
-
 class Vim
   eval: (vimL) ->
     return vim.api.nvim_eval(vimL)
@@ -109,15 +103,20 @@ timeStampIsGreater = (file1Path, file2Path) ->
     return time1 > time2
 
 class MoonMaker
-  compiler: moon_compiler
+  getCompiler: () ->
+      if Vim.callFunction('exists', {'MoonCompiler'}) == 1
+          return vim.api.nvim_get_var('MoonCompiler')
+      else
+          return "moonc"
+
   executeMoon: (moonText) ->
-    local moon_cmd = compiler .. " --"
+    local moon_cmd = getCompiler() .. " --"
     luaText = Vim.callFunction("system", { moon_cmd, moonText })
     loadstring(luaText)!
 
   -- Returns true if it was compiled
   compileMoonIfOutOfDate: (moonPath, luaPath) ->
-    local moon_cmd = compiler .. " -o "
+    local moon_cmd = getCompiler() .. " -o "
     if not File.exists(luaPath) or timeStampIsGreater(moonPath, luaPath)
       Path.makeMissingDirectoriesInPath(luaPath)
       output = Vim.callFunction("system", { moon_cmd .. "#{luaPath} " .. "#{moonPath}" })


### PR DESCRIPTION
This simply gives the option to the user to use a different Moonscript compiler. Which, at the moment is only [Yuescript](https://github.com/pigpigyyy/Yuescript).

All I really added to do this was:

```
moon_compiler = vim.g.moon_compiler or "moonc"
```

As well as change the `MoonMaker.executeMoon` and `MoonMaker.compileMoonIfOutOfDate`.

Yuescript is a bit more up-to-date and, allegedly, allows to more extensibility to the language. It can also create minified Lua scripts with it's `-m` option.